### PR TITLE
Introduce Tabs Control

### DIFF
--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -9,6 +9,8 @@ import {
   MovableWindow,
   ScrollingText,
   StaticWindow,
+  Tab,
+  Tabs,
   TextInput,
   TinyButton,
 } from '../lib';
@@ -73,11 +75,26 @@ function App() {
             onSelect={oneArg(onSelect)} />
         </Section>
 
+        <Section>
+          <Tabs selected="Tab Three">
+            <Tab label="Tab One">
+              <p>Tab one content.</p>
+            </Tab>
+            <Tab label="Tab Two">
+              <p>Tab two content.</p>
+            </Tab>
+            <Tab label="Tab Three">
+              <p>Tab three content.</p>
+            </Tab>
+          </Tabs>
+        </Section>
+
         <Group title="What is this?">
           <p>Ninetyfive is a collection of React.js components that make a web page look like a Windows 95 program.</p>
           <p>Press the "?" button for a demo of movable windows.</p>
           <p><a href="https://github.com/irskep/ninetyfive">Docs may be found here.</a></p>
         </Group>
+
       </StaticWindow>
 
       <MovableWindow

--- a/src/lib/Tab.jsx
+++ b/src/lib/Tab.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Tab({children, className}) {
+  return (
+    <div className="{`W95__Tab ${className || ''}`}">
+      {children}
+    </div>
+  );
+}

--- a/src/lib/Tabs.jsx
+++ b/src/lib/Tabs.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+export default function Tabs({children, selected, className}) {
+  const tabs = React.Children.toArray(children);
+  const labels = tabs.map(childTab => childTab.props.label);
+  const initialState = selected ? labels.indexOf(selected) || 0 : 0;
+  const [selectedIndex, setSelectedIndex] = useState(initialState);
+
+  return (
+    <div className={`W95__Tabs ${className || ''}`}>
+      <ul className="W95__Tabs__Labels">
+        {labels.map((label, index) => {
+          const selectedClassName = index == selectedIndex ? 'm-selected' : '';
+          return (
+            <li key={label} className="W95__Tabs__Label">
+              <button className={`W95__Tabs__Button ${selectedClassName}`} onClick={() => setSelectedIndex(index)}>
+                {label}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+      <div className="W95__Tabs__Content">
+        {tabs[selectedIndex]}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/Tabs.scss
+++ b/src/lib/Tabs.scss
@@ -1,0 +1,49 @@
+.W95__Tabs {
+  margin: $contentPadding 0;
+}
+
+.W95__Tabs__Labels {
+  display: flex;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  align-items: baseline;
+}
+
+.W95__Tabs__Button {
+  border: 0;
+  display: inline-block;
+  @include ButtonLike;
+  border-bottom: none;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  box-shadow: inset -2px 0 0 #828282;
+  font-size: 18px;
+  height: 38px;
+
+  &.m-selected {
+    height: 42px;
+  }
+
+  &:active {
+    border-left: 2px solid #fff;
+    border-top: 2px solid #fff;
+    border-bottom: none;
+  }
+}
+
+.W95__Tabs__Content {
+  margin-top: -2px;
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #000;
+  border-bottom: 2px solid #000;
+}
+
+.W95__Tab {
+  border-left: 2px solid var(--bg);
+  border-top: 2px solid var(--bg);
+  border-right: 2px solid #828282;
+  border-bottom: 2px solid #828282;
+  padding: 12px;
+}

--- a/src/lib/general.scss
+++ b/src/lib/general.scss
@@ -4,6 +4,7 @@
 @import "Group";
 @import "List";
 @import "ScrollingText";
+@import "Tabs";
 @import "TextInput";
 @import "TinyButton";
 @import "WindowCommon";

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -6,6 +6,8 @@ import List from './List.jsx';
 import MovableWindow from './MovableWindow.jsx';
 import ScrollingText from './ScrollingText.jsx';
 import StaticWindow from './StaticWindow.jsx';
+import Tab from './Tab.jsx';
+import Tabs from './Tabs.jsx';
 import TextInput from './TextInput.jsx';
 import TinyButton from './TinyButton.jsx';
 import __ from './general.scss';
@@ -19,6 +21,8 @@ export {
   MovableWindow,
   ScrollingText,
   StaticWindow,
+  Tab,
+  Tabs,
   TextInput,
   TinyButton,
 }


### PR DESCRIPTION
Replicates the appearance of the standard W95 tabs with clickable labels that show and hide the associated content regions. There are many different ways to implement tabs in React. This approach is mostly aimed at ensuring no state management stuff is required for users of the library and ensuring that the tabs look similar to the existing components at the top level (though this is complicated by the need to have `Tab` components nested inside `Tabs`, a constraint that might not be as simple as other parts of the library).

Currently doesn’t support custom props for events (`onEnterTab`, `onLeaveTab`, etc) and doesn’t have an explicit API for focusing/switching to a tab programatically. All this would be possible to add, just want to start with something simple that might be useful.

# Screenshot of the original Windows 95 control

![image](https://user-images.githubusercontent.com/24809/54083814-a4739a00-438d-11e9-8d47-2d6e68ef6543.png)

# Screenshot of your code in action

![image](https://user-images.githubusercontent.com/24809/54083795-68403980-438d-11e9-90d7-7399a1aa565f.png)

# CSS classes introduced

```
.W95__Tabs
  .W95__Tabs__Labels
    .W95__Tabs__Button
  .W95__Tabs__Content
    .W95__Tab
```

# React component API changes

Introduced two new exported components: `Tabs`, representing the wrapper for the control and the current selection state and `Tab`, representing an individual clickable label and its associated content region.