### PR TITLE
Hide non-thematic scrollbars in Firefox

### DIFF
--- a/src/lib/List.scss
+++ b/src/lib/List.scss
@@ -15,6 +15,7 @@
   padding-left: 4px;
   overflow-x: scroll;
   overflow-y: hidden;
+  scrollbar-width: none;
 
   &:hover {
     padding-left: 2px;

--- a/src/lib/ScrollingText.scss
+++ b/src/lib/ScrollingText.scss
@@ -15,7 +15,7 @@
 
 .W95__ScrollingText__Content {
   padding: $windowPadding * 2;
-  overflow: scroll;
+  overflow-y: scroll;
   max-height: 100%;
 
   font-family: 'Times New Roman', Times, serif;


### PR DESCRIPTION
# Summary

FIrefox shows ugly horizontal scroll bars in list items and scrollable text containers:

![Screenshot 2019-05-14 11 00 15](https://user-images.githubusercontent.com/38225497/57720837-8a796080-7637-11e9-8a5a-f208b0c03015.png)

# Screenshot of the original Windows 95 control

Omitted

# Screenshot of your code in action

![Screenshot 2019-05-14 11 03 12](https://user-images.githubusercontent.com/38225497/57720991-e9d77080-7637-11e9-9e24-f5a5deb91db9.png)

# Code API changes

n/a

# CSS classes introduced

none

# React component API changes

none